### PR TITLE
Update hearing_aids.json(Update locationSet for Amplifon)

### DIFF
--- a/data/brands/shop/hearing_aids.json
+++ b/data/brands/shop/hearing_aids.json
@@ -18,7 +18,7 @@
     {
       "displayName": "Amplifon",
       "id": "amplifon-6f1b2d",
-      "locationSet": {"include": ["001"]},
+      "locationSet": {"include": ["it", "gb", "us", "ca"]},
       "matchNames": [
         "amplifon deutschland gmbh",
         "amplifon france"


### PR DESCRIPTION
Update locationSet for Amplifon to include the countries IT, GB, US, and CA.

https://www.wikidata.org/wiki/Q477222