### PR TITLE
Update hardware.json (Add New Brand for CAN)

### DIFF
--- a/data/brands/shop/hardware.json
+++ b/data/brands/shop/hardware.json
@@ -479,6 +479,16 @@
         "name": "Мосхозторг",
         "shop": "hardware"
       }
+    },
+    {
+      "displayName": "BMR",
+      "locationSet": {"include": ["ca"]},
+      "tags": {
+        "brand": "BMR",
+        "brand:wikidata": "Q3117331",
+        "name": "BMR",
+        "shop": "hardware"
+      }
     }
   ]
 }


### PR DESCRIPTION
Adding a new brand for shop=hardware in Canada.

https://www.wikidata.org/wiki/Q3117331
https://www.bmr.ca/en/