### PR TITLE
Update paint.json(Update brand name to match Wikidata)

### DIFF
--- a/data/brands/shop/paint.json
+++ b/data/brands/shop/paint.json
@@ -127,14 +127,14 @@
       }
     },
     {
-      "displayName": "Dulux Paints",
+      "displayName": "Dulux",
       "id": "duluxpaints-573ec1",
       "locationSet": {"include": ["001"]},
-      "matchNames": ["dulux"],
+      "matchNames": ["dulux", "Dulux Paints"],
       "tags": {
-        "brand": "Dulux Paints",
+        "brand": "Dulux",
         "brand:wikidata": "Q50921",
-        "name": "Dulux Paints",
+        "name": "Dulux",
         "shop": "paint"
       }
     },


### PR DESCRIPTION
Updated brand name for Dulux to match Wikidata and official website.

https://www.wikidata.org/wiki/Q50921
https://dulux.ca/