### PR TITLE
Update social_centre.json(Update brand CAN)

### DIFF
--- a/data/brands/amenity/social_centre.json
+++ b/data/brands/amenity/social_centre.json
@@ -173,14 +173,15 @@
       }
     },
     {
-      "displayName": "Royal Canadian Legion Hall",
+      "displayName": "Royal Canadian Legion",
       "id": "royalcanadianlegionhall-c03cd4",
       "locationSet": {"include": ["ca"]},
+      "matchNames": ["Royal Canadian Legion Hall"],
       "tags": {
         "amenity": "social_centre",
         "brand": "Royal Canadian Legion",
         "brand:wikidata": "Q3270231",
-        "name": "Royal Canadian Legion Hall",
+        "name": "Royal Canadian Legion",
         "short_name": "RCL",
         "social_centre:for": "veteran"
       }


### PR DESCRIPTION
Updated the name for Royal Canadian Legion to match Wikidata and official website.

https://www.wikidata.org/wiki/Q3270231
https://legion.ca/